### PR TITLE
Multithreaded Partition Optimization

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/config/TimedJobExecutionListener.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/TimedJobExecutionListener.java
@@ -1,0 +1,43 @@
+package com.sparta.settlementservice.batch.config;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimedJobExecutionListener implements JobExecutionListener {
+
+    private long startTime;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        startTime = System.currentTimeMillis();
+        System.out.println("[Job] Starting job...");
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        long endTime = System.currentTimeMillis();
+        long durationMillis = endTime - startTime;
+        double durationSeconds = durationMillis / 1000.0;
+
+        // 총 처리량 (Step 처리량 합산)
+        int totalProcessed = jobExecution.getStepExecutions()
+                .stream()
+                .mapToInt(step -> (int) step.getReadCount()) // long을 int로 변환
+                .sum();
+
+        // 초당 처리량 계산
+        double throughput = totalProcessed / durationSeconds;
+
+        System.out.println("[Job] Job finished.");
+        System.out.println("[Job] Total Duration: " + durationSeconds + " seconds");
+        System.out.println("[Job] Total Processed Items: " + totalProcessed);
+        System.out.println("[Job] Throughput: " + throughput + " items/second");
+
+        // 30초 초과 시 경고 출력
+        if (durationMillis >= 30000) {
+            System.out.println("[Job] Execution timed out after 30 seconds.");
+        }
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/batch/config/TimedStepListener.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/TimedStepListener.java
@@ -1,0 +1,29 @@
+package com.sparta.settlementservice.batch.config;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.listener.StepExecutionListenerSupport;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimedStepListener extends StepExecutionListenerSupport {
+
+    private final long startTime = System.currentTimeMillis();
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        long currentTime = System.currentTimeMillis();
+        long elapsedTimeMillis = currentTime - startTime;
+        double elapsedTimeSeconds = elapsedTimeMillis / 1000.0;
+
+        int readCount = (int) stepExecution.getReadCount();
+        double throughput = readCount / elapsedTimeSeconds;
+
+        System.out.println("[Partition] Step: " + stepExecution.getStepName());
+        System.out.println("[Partition] Time elapsed: " + elapsedTimeSeconds + " seconds");
+        System.out.println("[Partition] Processed items: " + readCount);
+        System.out.println("[Partition] Throughput: " + throughput + " items/second");
+
+        return stepExecution.getExitStatus();
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/batch/config/VideoIdPartitioner.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/VideoIdPartitioner.java
@@ -9,21 +9,35 @@ import java.util.Map;
 public class VideoIdPartitioner implements Partitioner {
     @Override
     public Map<String, ExecutionContext> partition(int gridSize) {
+        System.out.println("[Partitioner] Partitioning data into " + gridSize + " parts");
         Map<String, ExecutionContext> partitionMap = new HashMap<>();
+
         long minVideoId = 1;  // videoId 최소 값
         long maxVideoId = 4000; // videoId 최대 값
+
+        // 파티션 크기 계산 (전체 범위를 gridSize로 나누기)
         long partitionSize = (maxVideoId - minVideoId + 1) / gridSize;
 
         for (int i = 0; i < gridSize; i++) {
             long lowerBound = minVideoId + (i * partitionSize);
-            long upperBound = (i == gridSize - 1) ? maxVideoId : (lowerBound + partitionSize - 1);
+            long upperBound = lowerBound + partitionSize - 1;
+
+            // 범위가 올바르게 점프하도록 1, 1001, 2001 ... 이렇게 설정
+            if (i == gridSize - 1) {
+                upperBound = maxVideoId; // 마지막 파티션의 upperBound가 maxVideoId로 설정
+            }
 
             ExecutionContext context = new ExecutionContext();
             context.putLong("lowerBound", lowerBound);
             context.putLong("upperBound", upperBound);
 
             partitionMap.put("partition" + i, context);
+
+            // 로그 추가
+            System.out.println("Partition " + i + ": lowerBound=" + lowerBound + ", upperBound=" + upperBound);
         }
+
         return partitionMap;
     }
+
 }

--- a/src/main/java/com/sparta/settlementservice/repository/DailyVideoViewRepository.java
+++ b/src/main/java/com/sparta/settlementservice/repository/DailyVideoViewRepository.java
@@ -45,4 +45,6 @@ public interface DailyVideoViewRepository extends JpaRepository<DailyVideoView, 
     List<DailyVideoView> findByVideoIdGreaterThan(Long lastVideoId, PageRequest of);
 
     List<DailyVideoView> findByVideoIdGreaterThanOrderByVideoId(Long lastProcessedId, PageRequest of);
+
+    List<DailyVideoView> findByVideoIdBetweenOrderByVideoId(Long lastProcessedId, Long upperBound, PageRequest of);
 }


### PR DESCRIPTION
- PartitionHandler와 TaskExecutor를 활용해 병렬 처리 구현.
- 파티션별로 정확한 데이터 범위를 설정하고 처리.(1000단위)
- 최적화 시간 측정 코드 구성 중

트러블 슈팅
-  ItemReader 매개변수 업데이트(lowerBound,upperBound), 모든 파티션이 videoId 1부터 시작되던 문제를 해결.

병렬 처리로 데이터 처리 성능 향상