### PR TITLE
Hibernate의 네이밍 전략

### DIFF
--- a/src/main/java/com/sparta/settlementservice/streaming/entity/DailyVideoView.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/entity/DailyVideoView.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 @Setter
 @NoArgsConstructor
 @Table(
-        name = "daily_video_view",
         indexes = {
                 @Index(name = "idx_video_id", columnList = "videoId"), // 기존 인덱스
         }

--- a/src/main/java/com/sparta/settlementservice/streaming/entity/VideoViewHistory.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/entity/VideoViewHistory.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
-@Table(name = "videohistory")
 @Getter
 @Setter
 public class VideoViewHistory {

--- a/src/main/java/com/sparta/settlementservice/streaming/entity/Videos.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/entity/Videos.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor
-@Table(name="videos")
 @Getter
 @Setter
 public class Videos {

--- a/src/main/java/com/sparta/settlementservice/user/controller/MainController.java
+++ b/src/main/java/com/sparta/settlementservice/user/controller/MainController.java
@@ -1,16 +1,21 @@
 package com.sparta.settlementservice.user.controller;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 public class MainController {
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @GetMapping("/")
     @ResponseBody
     public String mainAPI() {
 
+        System.out.println(entityManager.getProperties().get("hibernate.physical_naming_strategy"));
         return "main route";
     }
 }

--- a/src/main/java/com/sparta/settlementservice/user/entity/UserEntity.java
+++ b/src/main/java/com/sparta/settlementservice/user/entity/UserEntity.java
@@ -17,7 +17,7 @@ public class UserEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "uploadingUser", cascade = CascadeType.ALL) // ✅ 연관관계 설정
+    @OneToMany(mappedBy = "uploadingUser", cascade = CascadeType.ALL) //  연관관계 설정
     private List<Videos> uploadedVideos = new ArrayList<>();
 
     private String username;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,13 +16,15 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
     properties:
       hibernate:
         show_sql: true
         format_sql: true
         use_sql_comments: true
-    naming:
-      physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
 
   batch:
     job:


### PR DESCRIPTION
- PhysicalNamingStrategyStandardImpl 설정을 추가하여 엔티티 필드명을 그대로 DB 컬럼명으로 매핑