### PR TITLE
일간 TOP 5 통계 배치 처리 기능 추가

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/dto/VideoViewStats.java
+++ b/src/main/java/com/sparta/settlementservice/batch/dto/VideoViewStats.java
@@ -1,0 +1,15 @@
+package com.sparta.settlementservice.batch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VideoViewStats {
+    private Long videoId;      // 비디오 ID
+    private Long totalValue;   // 조회수 or 재생 시간 (statType에 따라 다름)
+    private String statType;   // "VIEW_COUNT" 또는 "PLAY_TIME"
+}
+

--- a/src/main/java/com/sparta/settlementservice/batch/entity/Top5Statistics.java
+++ b/src/main/java/com/sparta/settlementservice/batch/entity/Top5Statistics.java
@@ -28,7 +28,7 @@ public class Top5Statistics {
 
     private Long videoId; //  비디오 ID
 
-    private int rank;
+    private int ranking;
 
     private Long value; // 해당 기준의 수치 (조회수 or 재생 시간)
 

--- a/src/main/java/com/sparta/settlementservice/batch/repo/Top5StatisticsRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/Top5StatisticsRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.settlementservice.batch.repo;
+
+import com.sparta.settlementservice.batch.entity.Top5Statistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface Top5StatisticsRepository extends JpaRepository<Top5Statistics, Long> {
+}

--- a/src/main/java/com/sparta/settlementservice/batch/schedule/StatisticsSchedule.java
+++ b/src/main/java/com/sparta/settlementservice/batch/schedule/StatisticsSchedule.java
@@ -5,6 +5,7 @@ import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.context.annotation.Configuration;
@@ -25,151 +26,57 @@ public class StatisticsSchedule {
     }
 
     // Daily Static 배치 처리
-    @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE) // 스케줄러 설정
-    public void runDailyStatisticsJob() {
-        long startTime = System.currentTimeMillis(); // 시작 시간 기록
+//    @Scheduled(initialDelay = 4000, fixedRate = Long.MAX_VALUE) // 스케줄러 설정
+//    public void runDailyStatisticsJob() {
+//        long startTime = System.currentTimeMillis(); // 시작 시간 기록
+//
+//        try {
+//            Job job = jobRegistry.getJob("dailyStatisticsJob");
+//            // 현재 시간을 기반으로 jobParameters 설정 (매 실행 시 고유한 파라미터 생성)
+//            jobLauncher.run(job, new JobParametersBuilder()
+//                    .addString("runDate", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE)) // 실행 날짜 추가
+//                    .addLong("timestamp", System.currentTimeMillis()) // 매번 고유 실행을 보장하는 timestamp
+//                    .toJobParameters());
+//
+//        } catch (JobExecutionAlreadyRunningException | JobRestartException e) {
+//            System.err.println("Job이 이미 실행 중이거나 재시작할 수 없습니다: " + e.getMessage());
+//        } catch (Exception e) {
+//            System.err.println("Job 실행 중 예외 발생: " + e.getMessage());
+//        }
+//
+//        long endTime = System.currentTimeMillis(); // 종료 시간 기록
+//        long executionTime = endTime - startTime; // 실행 시간 계산
+//
+//        System.out.println("Daily Statistics Job Execution Time: " + executionTime + " ms");
+//    }
+
+
+    // ✅ Spring Boot 시작 후 5초 뒤에 한 번만 실행
+    @Scheduled(initialDelay = 4000, fixedRate = Long.MAX_VALUE)
+    public void runDailyTop5StatisticsJob() {
+        long startTime = System.currentTimeMillis(); // ✅ 시작 시간 기록
 
         try {
-            Job job = jobRegistry.getJob("dailyStatisticsJob");
-            // 현재 시간을 기반으로 jobParameters 설정 (매 실행 시 고유한 파라미터 생성)
+            Job job = jobRegistry.getJob("top5StatisticsBatchJob");  // ✅ Job 이름 변경 (올바른 Job 실행)
+
+            // ✅ 현재 시간을 기반으로 jobParameters 설정 (중복 실행 방지)
             jobLauncher.run(job, new JobParametersBuilder()
                     .addString("runDate", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE)) // 실행 날짜 추가
-                    .addLong("timestamp", System.currentTimeMillis()) // 매번 고유 실행을 보장하는 timestamp
+                    .addLong("timestamp", System.currentTimeMillis()) // ✅ 매번 고유 실행을 보장하는 timestamp
                     .toJobParameters());
 
+        } catch (NoSuchJobException e) {
+            System.err.println("등록된 Job을 찾을 수 없습니다: " + e.getMessage());
         } catch (JobExecutionAlreadyRunningException | JobRestartException e) {
             System.err.println("Job이 이미 실행 중이거나 재시작할 수 없습니다: " + e.getMessage());
         } catch (Exception e) {
             System.err.println("Job 실행 중 예외 발생: " + e.getMessage());
         }
 
-        long endTime = System.currentTimeMillis(); // 종료 시간 기록
-        long executionTime = endTime - startTime; // 실행 시간 계산
+        long endTime = System.currentTimeMillis(); // ✅ 종료 시간 기록
+        long executionTime = endTime - startTime; // ✅ 실행 시간 계산
 
         System.out.println("Daily Statistics Job Execution Time: " + executionTime + " ms");
     }
-
-
-    // 매번 애플리케이션 시작 후 7초 뒤에 한 번 실행
-//    @Scheduled(initialDelay = 7000, fixedRate = Long.MAX_VALUE)
-//    public void runDailyStatisticsJob() throws Exception {
-//        JobParameters jobParameters = new JobParametersBuilder()
-//                .addString("period", "day") // 1일 통계
-//                .addLong("time", System.currentTimeMillis()) // 유니크한 파라미터 추가
-//                .toJobParameters();
-//        jobLauncher.run(jobRegistry.getJob("statisticsJob"), jobParameters);
-//    }
-
-    // 매일 자정에 1일 통계 처리
-
-
-
-
-    // 1주 week static 배치처리
-//    @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE)
-//    public void runWeeklyStatisticsJob() {
-//        try {
-//            Job job = jobRegistry.getJob("weeklyStatisticsJob");
-//
-//            // 현재 시간을 기반으로 jobParameters 설정 (매 실행 시 고유한 파라미터 생성)
-//            jobLauncher.run(job, new JobParametersBuilder()
-//                    .addString("startDate", LocalDateTime.now().minusDays(7).format(DateTimeFormatter.ISO_DATE))
-//                    .addString("endDate", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-//                    .addLong("timestamp", System.currentTimeMillis()) // 매번 다른 timestamp로 고유 실행
-//                    .toJobParameters());
-//
-//        } catch (JobExecutionAlreadyRunningException | JobRestartException e) {
-//            System.err.println("Job이 이미 실행 중이거나 재시작할 수 없습니다: " + e.getMessage());
-//        } catch (Exception e) {
-//            System.err.println("Job 실행 중 예외 발생: " + e.getMessage());
-//        }
-//    }
-
-
-
-
-  // week to5 통계 처리
-//  @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE)
-//  public void runWeeklyTop5StatisticsJob() {
-//      try {
-//          Job weeklyStatisticsJob = jobRegistry.getJob("weekTop5StatisticsJob");
-//          JobParameters jobParameters = new JobParametersBuilder()
-//                  .addString("runTime", LocalDateTime.now().toString()) // 매번 새로운 파라미터로 실행
-//                  .toJobParameters();
-//
-//          JobExecution jobExecution = jobLauncher.run(weeklyStatisticsJob, jobParameters);
-//          System.out.println("Batch Job Status: " + jobExecution.getStatus());
-//      } catch (Exception e) {
-//          e.printStackTrace();
-//          System.out.println("Error occurred while executing the batch job: " + e.getMessage());
-//      }
-//  }
-
-
-   // 월 단위 통계처리
-//    @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE)
-//    public void runMonthlyStatisticsJob() {
-//        long startTime = System.currentTimeMillis();  // 시작 시간 기록
-//        try {
-//            Job job = jobRegistry.getJob("monthlyStatisticsJob");
-//
-//            // 현재 시간을 기반으로 jobParameters 설정 (매 실행 시 고유한 파라미터 생성)
-//            jobLauncher.run(job, new JobParametersBuilder()
-//                    .addString("startDate", LocalDateTime.now().minusDays(7).format(DateTimeFormatter.ISO_DATE))
-//                    .addString("endDate", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-//                    .addLong("timestamp", System.currentTimeMillis()) // 매번 다른 timestamp로 고유 실행
-//                    .toJobParameters());
-//
-//        } catch (JobExecutionAlreadyRunningException | JobRestartException e) {
-//            System.err.println("Job이 이미 실행 중이거나 재시작할 수 없습니다: " + e.getMessage());
-//        } catch (Exception e) {
-//            System.err.println("Job 실행 중 예외 발생: " + e.getMessage());
-//        }
-//        long endTime = System.currentTimeMillis();  // 종료 시간 기록
-//          long executionTime = endTime - startTime;   // 실행 시간 계산
-//
-//          System.out.println("Monthly Statistics Job Execution Time: " + executionTime + " ms");
-//    }
-//
-//
-//      @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE)
-//  public void runMonthlyTop5StatisticsJob() {
-//          long startTime = System.currentTimeMillis();  // 시작 시간 기록
-//      try {
-//          Job weeklyStatisticsJob = jobRegistry.getJob("monthTop5StatisticsJob");
-//          JobParameters jobParameters = new JobParametersBuilder()
-//                  .addString("runTime", LocalDateTime.now().toString()) // 매번 새로운 파라미터로 실행
-//                  .toJobParameters();
-//
-//          JobExecution jobExecution = jobLauncher.run(weeklyStatisticsJob, jobParameters);
-//          System.out.println("Batch Job Status: " + jobExecution.getStatus());
-//      } catch (Exception e) {
-//          e.printStackTrace();
-//          System.out.println("Error occurred while executing the batch job: " + e.getMessage());
-//      }
-//
-//          long endTime = System.currentTimeMillis();  // 종료 시간 기록
-//          long executionTime = endTime - startTime;   // 실행 시간 계산
-//
-//          System.out.println("Monthly Top 5 Statistics Job Execution Time: " + executionTime + " ms");
-//  }
-
-
-//          @Scheduled(initialDelay = 5000, fixedRate = Long.MAX_VALUE)
-//  public void runDailyTop5StatisticsJob() {
-//      try {
-//          Job weeklyStatisticsJob = jobRegistry.getJob("dailyTop5StatisticsJob");
-//          JobParameters jobParameters = new JobParametersBuilder()
-//                  .addString("runTime", LocalDateTime.now().toString()) // 매번 새로운 파라미터로 실행
-//                  .toJobParameters();
-//
-//          JobExecution jobExecution = jobLauncher.run(weeklyStatisticsJob, jobParameters);
-//          System.out.println("Batch Job Status: " + jobExecution.getStatus());
-//      } catch (Exception e) {
-//          e.printStackTrace();
-//          System.out.println("Error occurred while executing the batch job: " + e.getMessage());
-//      }
-//  }
-
 
 }

--- a/src/main/java/com/sparta/settlementservice/batch/settlementbatch/DailyStatisticBatch.java
+++ b/src/main/java/com/sparta/settlementservice/batch/settlementbatch/DailyStatisticBatch.java
@@ -30,7 +30,7 @@ import java.time.LocalDate;
 import java.util.*;
 
 @Configuration
-public class DailyStaticBatch {
+public class DailyStatisticBatch {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
@@ -38,7 +38,7 @@ public class DailyStaticBatch {
     private final TaskExecutor taskExecutor;
 
     @Autowired
-    public DailyStaticBatch(JobRepository jobRepository,
+    public DailyStatisticBatch(JobRepository jobRepository,
                             PlatformTransactionManager platformTransactionManager,
                             DailyViewPlaytimeJdbcRepository dailyViewPlaytimeJdbcRepository,
                             TaskExecutor taskExecutor

--- a/src/main/java/com/sparta/settlementservice/batch/settlementbatch/Top5StatisticBatch.java
+++ b/src/main/java/com/sparta/settlementservice/batch/settlementbatch/Top5StatisticBatch.java
@@ -1,0 +1,116 @@
+package com.sparta.settlementservice.batch.settlementbatch;
+
+import com.sparta.settlementservice.batch.dto.VideoViewStats;
+import com.sparta.settlementservice.batch.entity.Top5Statistics;
+import com.sparta.settlementservice.batch.repo.DailyViewPlaytimeJdbcRepository;
+import com.sparta.settlementservice.batch.repo.Top5StatisticsRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class Top5StatisticBatch {
+
+    private final DailyViewPlaytimeJdbcRepository dailyViewPlaytimeJdbcRepository;
+    private final Top5StatisticsRepository top5StatisticsRepository;
+
+    public Top5StatisticBatch(
+            DailyViewPlaytimeJdbcRepository dailyViewPlaytimeJdbcRepository
+            , Top5StatisticsRepository top5StatisticsRepository) {
+
+        this.dailyViewPlaytimeJdbcRepository = dailyViewPlaytimeJdbcRepository;
+        this.top5StatisticsRepository = top5StatisticsRepository;
+    }
+
+    @Bean
+    public Job top5StatisticsBatchJob(JobRepository jobRepository, Step dailyTop5Step) {
+        return new JobBuilder("top5StatisticsBatchJob", jobRepository)
+                .start(dailyTop5Step)
+                .build();
+    }
+
+    @Bean
+    public Step dailyTop5Step(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("dailyTop5Step", jobRepository)
+                .<VideoViewStats, Top5Statistics>chunk(100, transactionManager)
+                .reader(dailyTop5Reader())
+                .processor(dailyTop5Processor())
+                .writer(dailyTop5Writer()) //
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<VideoViewStats> dailyTop5Reader() {
+        return new ItemReader<>() {
+            private final List<VideoViewStats> buffer = new ArrayList<>();
+            private int nextIndex = 0;
+            private boolean loaded = false;
+            private final LocalDate targetDate = LocalDate.now();
+
+
+            @Override
+            public VideoViewStats read() {
+                if (!loaded) {
+                    //paging 방식 -> buffer 방식
+                    //가져올 데이터 크기가 그렇게 크지 않고, top5만가져오면 되기 때문
+                    List<VideoViewStats> viewCountStats = dailyViewPlaytimeJdbcRepository.findTop5ByStatType(targetDate, "VIEW_COUNT");
+                    List<VideoViewStats> playTimeStats = dailyViewPlaytimeJdbcRepository.findTop5ByStatType(targetDate, "PLAY_TIME");
+
+                    System.out.println("📌 [ItemReader] 조회된 VIEW_COUNT 데이터 개수: " + viewCountStats.size());
+                    System.out.println("📌 [ItemReader] 조회된 PLAY_TIME 데이터 개수: " + playTimeStats.size());
+                    buffer.addAll(viewCountStats);
+                    buffer.addAll(playTimeStats);
+                    loaded = true;
+                }
+                return nextIndex < buffer.size() ? buffer.get(nextIndex++) : null;
+            }
+        };
+    }
+
+    @Bean
+    public ItemProcessor<VideoViewStats, Top5Statistics> dailyTop5Processor() {
+        return item -> {
+            System.out.println("🔍 [ItemProcessor] 변환 중 - videoId: " + item.getVideoId() + ", totalValue: " + item.getTotalValue());
+
+            return Top5Statistics.builder()
+                    .date(LocalDate.now())
+                    .dateType("DAILY")
+                    .staticType(item.getStatType())
+                    .videoId(item.getVideoId())
+                    .value(item.getTotalValue())
+                    .build();
+        };
+    }
+
+
+    @Bean
+    public ItemWriter<Top5Statistics> dailyTop5Writer() {
+        return items -> {
+            System.out.println("🔍 [ItemWriter] 저장할 데이터 개수: " + items.size());
+
+            if (!items.isEmpty()) {
+                top5StatisticsRepository.saveAll(items);
+                System.out.println("✅ [ItemWriter] 데이터 저장 완료!");
+            } else {
+                System.out.println("⚠ [ItemWriter] 저장할 데이터가 없음!");
+            }
+        };
+    }
+}
+
+


### PR DESCRIPTION
- 조회수 및 재생 시간을 기준으로 일간 TOP 5 비디오 통계를 계산하는 배치 추가
- `dailyVideoView` 테이블에서 `createdAt` 기준으로 데이터 조회하는 ItemReader 구현
- 조회된 데이터를 `Top5Statistics` 엔티티로 변환하는 ItemProcessor 구현
- 처리된 데이터를 `Top5Statistics` 테이블에 저장하는 ItemWriter 구현
- ItemReader에서 `buffer`에 데이터를 추가하지 않아 데이터가 전달되지 않던 문제 해결
- 배치 실행 로그 추가 및 데이터 저장 검증 완료