### PR TITLE
Top5 통계 배치에서 주간(WEEKLY) & 월간(MONTHLY) 통계 추가

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
@@ -1,0 +1,46 @@
+package com.sparta.settlementservice.batch.config;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.job.flow.FlowExecutionStatus;
+import org.springframework.batch.core.job.flow.JobExecutionDecider;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+@Component
+public class BatchExecutionDecider implements JobExecutionDecider {
+
+    //FlowExecutionStatus: Spring Batch에서 Step의 실행 상태를 결정하는 객체
+    @Override
+    public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
+        LocalDate today = LocalDate.parse("2025-02-10");
+
+        if (isMonday(today) && isFirstDayOfMonth(today)) {
+            System.out.println(" [Decider] 결과: WEEKLY_MONTHLY");
+            return new FlowExecutionStatus("WEEKLY_MONTHLY"); // ✅ 월요일 + 1일 → 둘 다 실행
+        } else if (isFirstDayOfMonth(today)) {
+            System.out.println(" [Decider] 결과: MONTHLY");
+            return new FlowExecutionStatus("MONTHLY"); // ✅ 1일이면 MONTHLY 실행
+        } else if (isMonday(today)) {
+            System.out.println(" [Decider] 결과: WEEKLY");
+            return new FlowExecutionStatus("WEEKLY"); // ✅ 월요일이면 WEEKLY 실행
+        }
+
+        System.out.println(" [Decider] 결과: DAILY");
+        return new FlowExecutionStatus("DAILY");
+
+    }
+
+    private boolean isMonday(LocalDate date) {
+        return date.getDayOfWeek() == DayOfWeek.MONDAY;
+    }
+
+    private boolean isFirstDayOfMonth(LocalDate date) {
+        boolean result = date.getDayOfMonth() == 1;
+        System.out.println(" [Decider] isFirstDayOfMonth(" + date + ") = " + result);
+        return date.getDayOfMonth() == 1;
+    }
+}
+

--- a/src/main/java/com/sparta/settlementservice/batch/dto/VideoViewStats.java
+++ b/src/main/java/com/sparta/settlementservice/batch/dto/VideoViewStats.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -11,5 +13,8 @@ public class VideoViewStats {
     private Long videoId;      // 비디오 ID
     private Long totalValue;   // 조회수 or 재생 시간 (statType에 따라 다름)
     private String statType;   // "VIEW_COUNT" 또는 "PLAY_TIME"
+    private String dateType;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }
 

--- a/src/main/java/com/sparta/settlementservice/batch/entity/Top5Statistics.java
+++ b/src/main/java/com/sparta/settlementservice/batch/entity/Top5Statistics.java
@@ -1,11 +1,13 @@
 package com.sparta.settlementservice.batch.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.jmx.support.MetricType;
 
 import java.time.LocalDate;
 
@@ -20,15 +22,13 @@ public class Top5Statistics {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDate date; //  기준 날짜 (해당 일/주/월의 마지막 날짜)
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String dateType; //  통계 유형 (DAILY, WEEKLY, MONTHLY)
 
     private String staticType; //  기준 (VIEW_COUNT, PLAY_TIME)
 
     private Long videoId; //  비디오 ID
-
-    private int ranking;
 
     private Long value; // 해당 기준의 수치 (조회수 or 재생 시간)
 

--- a/src/main/java/com/sparta/settlementservice/batch/repo/DailyViewPlaytimeJdbcRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/DailyViewPlaytimeJdbcRepository.java
@@ -86,23 +86,27 @@ public class DailyViewPlaytimeJdbcRepository {
 
 
     // 여기서 부터 Top5 배치 Jdbc 활용
-    // ✅ 하나의 메서드에서 statType에 따라 쿼리 실행
-    public List<VideoViewStats> findTop5ByStatType(LocalDate targetDate, String statType) {
+    //  하나의 메서드에서 statType에 따라 쿼리 실행
+    public List<VideoViewStats> findTop5ByStatType(LocalDate startDate, LocalDate endDate, String statType, String dateType) {
         String orderByColumn = statType.equals("VIEW_COUNT") ? "SUM(viewCount)" : "SUM(playTime)";
 
         String sql = "SELECT videoId, " + orderByColumn + " AS totalValue " +
                 "FROM dailyVideoView " +
-                "WHERE DATE(createdAt) = ? " +  // ✅ 특정 날짜만 조회하도록 수정
+                "WHERE DATE(createdAt) BETWEEN ? AND ? " +  //  startDate ~ endDate 범위 조회
                 "GROUP BY videoId " +
                 "ORDER BY totalValue DESC " +
-                "LIMIT 5";  // ✅ TOP 5 고정
+                "LIMIT 5";  //  TOP 5
 
         return jdbcTemplate.query(sql, (rs, rowNum) -> new VideoViewStats(
                 rs.getLong("videoId"),
                 rs.getLong("totalValue"),
-                statType
-        ), targetDate);
+                statType,
+                dateType,   // 추가: DAILY, WEEKLY, MONTHLY 값 전달
+                startDate,  // 추가: 시작 날짜
+                endDate     // 추가: 종료 날짜
+        ), startDate, endDate);
     }
+
 
 
 


### PR DESCRIPTION
- 기존 일일(DAILY) 통계에서 주간(WEEKLY), 월간(MONTHLY) 통계 기능 추가
- JDBC 쿼리를 수정하여 startDate, endDate를 매개변수로 받아 주간/월간 조회 가능하도록 개선
- Step 실행 조건을 제어하기 위해 BatchExecutionDecider 추가 (날짜 기반 실행 로직 적용)
- Reader를 DAILY, WEEKLY, MONTHLY 별도로 생성하고, Processor와 Writer는 공통으로 활용