### PR TITLE
SettlementResultJdbcRepository 정산 결과 저장 및 배치 로직 개선

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
@@ -15,17 +15,18 @@ public class BatchExecutionDecider implements JobExecutionDecider {
     //FlowExecutionStatus: Spring Batch에서 Step의 실행 상태를 결정하는 객체
     @Override
     public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
-        LocalDate today = LocalDate.now();
-
+        LocalDate today = LocalDate.of(2025, 3, 1);
+//        LocalDate today = LocalDate.now();
+        System.out.println(" [Decider] 실행됨! JobExecution ID: " + jobExecution.getId());
         if (isMonday(today) && isFirstDayOfMonth(today)) {
             System.out.println(" [Decider] 결과: WEEKLY_MONTHLY");
-            return new FlowExecutionStatus("WEEKLY_MONTHLY"); // ✅ 월요일 + 1일 → 둘 다 실행
+            return new FlowExecutionStatus("WEEKLY_MONTHLY"); //  월요일 + 1일 → 둘 다 실행
         } else if (isFirstDayOfMonth(today)) {
             System.out.println(" [Decider] 결과: MONTHLY");
-            return new FlowExecutionStatus("MONTHLY"); // ✅ 1일이면 MONTHLY 실행
+            return new FlowExecutionStatus("MONTHLY"); //  1일이면 MONTHLY 실행
         } else if (isMonday(today)) {
             System.out.println(" [Decider] 결과: WEEKLY");
-            return new FlowExecutionStatus("WEEKLY"); // ✅ 월요일이면 WEEKLY 실행
+            return new FlowExecutionStatus("WEEKLY"); //  월요일이면 WEEKLY 실행
         }
 
         System.out.println(" [Decider] 결과: DAILY");

--- a/src/main/java/com/sparta/settlementservice/batch/entity/DailyViewPlaytime.java
+++ b/src/main/java/com/sparta/settlementservice/batch/entity/DailyViewPlaytime.java
@@ -40,4 +40,12 @@ public class DailyViewPlaytime {
         this.totalViewCount = totalViewCount;
         this.totalAdViewCount = totalAdViewCount;
     }
+
+    public DailyViewPlaytime(long videoId, LocalDate createdAt, long totalViewCount, long totalAdViewCount, long totalPlayTime) {
+        this.videoId = videoId;
+        this.createdAt = createdAt ;
+        this.totalViewCount = totalViewCount;
+        this.totalAdViewCount = totalAdViewCount;
+        this.totalPlayTime = totalPlayTime;
+    }
 }

--- a/src/main/java/com/sparta/settlementservice/batch/repo/DailyViewPlaytimeJdbcRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/DailyViewPlaytimeJdbcRepository.java
@@ -2,6 +2,7 @@ package com.sparta.settlementservice.batch.repo;
 
 import com.sparta.settlementservice.batch.dto.VideoViewStats;
 import com.sparta.settlementservice.batch.entity.DailyViewPlaytime;
+import com.sparta.settlementservice.batch.entity.SettlementResult;
 import com.sparta.settlementservice.streaming.entity.DailyVideoView;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -108,6 +109,7 @@ public class DailyViewPlaytimeJdbcRepository {
 
 
     // Settlement 배치 Jdbc 활용
+
     public List<DailyViewPlaytime> findByDateBetweenOrderByDate(LocalDate startDate, LocalDate endDate, int pageSize) {
         String sql = "SELECT * FROM dailyviewplaytime " +  //  테이블명 언더바 제거
                 "WHERE createdAt  BETWEEN ? AND ? " +
@@ -121,8 +123,6 @@ public class DailyViewPlaytimeJdbcRepository {
                 rs.getLong("totalAdViewCount")  //  컬럼명 변경 (total_ad_view_count → totalAdViewCount)
         ), startDate, endDate, pageSize);
     }
-
-
 
 
 }

--- a/src/main/java/com/sparta/settlementservice/batch/repo/SettlementResultJdbcRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/SettlementResultJdbcRepository.java
@@ -1,0 +1,48 @@
+package com.sparta.settlementservice.batch.repo;
+
+import com.sparta.settlementservice.batch.entity.SettlementResult;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class SettlementResultJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public SettlementResultJdbcRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    //settlement 결과 저장
+    public void saveAllWithDuplicateCheckSettlement(List<SettlementResult> items) {
+        if (items.isEmpty()) return; // ✅ 저장할 데이터 없으면 바로 종료
+
+        String sql = """
+                INSERT INTO settlementResult (videoId, videoRevenue, adRevenue, totalRevenue, startDate, endDate, dateType)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON DUPLICATE KEY UPDATE 
+                videoRevenue = VALUES(videoRevenue),
+                adRevenue = VALUES(adRevenue),
+                totalRevenue = VALUES(totalRevenue),
+                startDate = VALUES(startDate),
+                endDate = VALUES(endDate),
+                dateType = VALUES(dateType)
+            """;
+
+        jdbcTemplate.batchUpdate(sql, items, items.size(), (ps, item) -> {
+            ps.setLong(1, item.getVideoId());
+            ps.setLong(2, item.getVideoRevenue());
+            ps.setLong(3, item.getAdRevenue());
+            ps.setLong(4, item.getTotalRevenue());
+            ps.setObject(5, item.getStartDate()); // LocalDate → DATE
+            ps.setObject(6, item.getEndDate()); // LocalDate → DATE
+            ps.setString(7, item.getDateType());
+        });
+
+        System.out.println("[INFO] Bulk Insert 완료! 저장 개수: " + items.size());
+    }
+
+
+}


### PR DESCRIPTION
- SettlementResultJdbcRepository를 활용하여 정산 결과 테이블 저장 처리
- batch 특성에 맞춰 weekly, monthly 조회수 합산을 위한 로직 개선
- afterStep() 추가하여 step 종료 시 videoId별 조회수 합산 후 최종 저장
- startDate를 SQL 조회와 저장 시 분리하여 데이터 무결성 유지