### PR TITLE
Top5 통계 & SettlementResult 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/BatchExecutionDecider.java
@@ -15,8 +15,8 @@ public class BatchExecutionDecider implements JobExecutionDecider {
     //FlowExecutionStatus: Spring Batch에서 Step의 실행 상태를 결정하는 객체
     @Override
     public FlowExecutionStatus decide(JobExecution jobExecution, StepExecution stepExecution) {
-//      LocalDate today = LocalDate.of(2025, 3, 1);
-        LocalDate today = LocalDate.now();
+      LocalDate today = LocalDate.of(2025, 2, 24);
+//        LocalDate today = LocalDate.now();
         System.out.println(" [Decider] 실행됨! JobExecution ID: " + jobExecution.getId());
         if (isMonday(today) && isFirstDayOfMonth(today)) {
             System.out.println(" [Decider] 결과: WEEKLY_MONTHLY");

--- a/src/main/java/com/sparta/settlementservice/batch/repo/SettlementResultRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/SettlementResultRepository.java
@@ -3,5 +3,9 @@ package com.sparta.settlementservice.batch.repo;
 import com.sparta.settlementservice.batch.entity.SettlementResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface SettlementResultRepository extends JpaRepository<SettlementResult, Long> {
+    List<SettlementResult> findByDateTypeAndStartDateBetween(String dateType, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/sparta/settlementservice/batch/repo/Top5StatisticsRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/Top5StatisticsRepository.java
@@ -3,6 +3,12 @@ package com.sparta.settlementservice.batch.repo;
 import com.sparta.settlementservice.batch.entity.Top5Statistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 
 public interface Top5StatisticsRepository extends JpaRepository<Top5Statistics, Long> {
+
+
+    List<Top5Statistics> findTop5ByDateTypeAndStartDateBetweenAndStaticTypeOrderByValueDesc(String dateType, LocalDate start, LocalDate end, String staticType);
 }

--- a/src/main/java/com/sparta/settlementservice/batch/schedule/BatchJobScheduler.java
+++ b/src/main/java/com/sparta/settlementservice/batch/schedule/BatchJobScheduler.java
@@ -62,4 +62,23 @@ public class BatchJobScheduler {
                 .toJobParameters();
     }
 
+
+//    @Scheduled(initialDelay = 4000, fixedRate = Long.MAX_VALUE)// 매일 새벽 1시 실행
+//    public void runTop5StatisticsBatch() {
+//        try {
+//            System.out.println("[Batch Scheduler] Top5 통계 배치 실행 시작 - " + LocalDateTime.now());
+//
+//            JobParameters jobParameters = new JobParametersBuilder()
+//                    .addLong("time", System.currentTimeMillis()) // 중복 실행 방지용 파라미터
+//                    .toJobParameters();
+//
+//            jobLauncher.run(top5StatisticsBatchJob, jobParameters);
+//
+//            System.out.println("[Batch Scheduler] Top5 통계 배치 실행 완료 - " + LocalDateTime.now());
+//        } catch (Exception e) {
+//            System.err.println("[Batch Scheduler] Top5 통계 배치 실행 중 오류 발생: " + e.getMessage());
+//            e.printStackTrace();
+//        }
+//    }
+
 }

--- a/src/main/java/com/sparta/settlementservice/settlement/controller/SettlementController.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/controller/SettlementController.java
@@ -1,0 +1,33 @@
+package com.sparta.settlementservice.settlement.controller;
+
+import com.sparta.settlementservice.batch.entity.SettlementResult;
+import com.sparta.settlementservice.settlement.service.SettlementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/settlement")
+@RequiredArgsConstructor
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @GetMapping("/{dateType}/{date}")
+    public ResponseEntity<List<SettlementResult>> getSettlement(
+            @PathVariable String dateType,
+            @PathVariable String date) {
+
+        LocalDate startDate = LocalDate.parse(date);
+        List<SettlementResult> settlementList = settlementService.getSettlement(dateType, startDate);
+
+        return ResponseEntity.ok(settlementList);
+    }
+}
+

--- a/src/main/java/com/sparta/settlementservice/settlement/controller/Top5StatisticsController.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/controller/Top5StatisticsController.java
@@ -1,0 +1,33 @@
+package com.sparta.settlementservice.settlement.controller;
+
+import com.sparta.settlementservice.batch.entity.Top5Statistics;
+import com.sparta.settlementservice.settlement.service.Top5StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/top5")
+@RequiredArgsConstructor
+public class Top5StatisticsController {
+
+    private final Top5StatisticsService top5StatisticsService;
+
+    @GetMapping("/{dateType}/{date}/{staticType}")
+    public ResponseEntity<List<Top5Statistics>> getTop5Statistics(
+            @PathVariable String dateType,
+            @PathVariable String date,
+            @PathVariable String staticType) {
+
+        LocalDate today = LocalDate.parse(date); // String → LocalDate 변환
+        List<Top5Statistics> top5 = top5StatisticsService.getTop5Statistics(dateType, today, staticType);
+
+        return ResponseEntity.ok(top5);
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/settlement/service/SettlementService.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/service/SettlementService.java
@@ -1,0 +1,38 @@
+package com.sparta.settlementservice.settlement.service;
+
+import com.sparta.settlementservice.batch.entity.SettlementResult;
+import com.sparta.settlementservice.batch.repo.SettlementResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+    private final SettlementResultRepository settlementResultRepository; //  변경됨
+
+    public List<SettlementResult> getSettlement(String dateType, LocalDate startDate) { // Settlement → SettlementResult
+        LocalDate start, end;
+
+        if ("DAILY".equalsIgnoreCase(dateType)) {
+            start = startDate;
+            end = startDate;
+        } else if ("WEEKLY".equalsIgnoreCase(dateType)) {
+            start = startDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)); // 주의 월요일
+            end = startDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)); // 주의 일요일
+        } else if ("MONTHLY".equalsIgnoreCase(dateType)) {
+            start = startDate.withDayOfMonth(1); // 월의 첫째 날
+            end = startDate.with(TemporalAdjusters.lastDayOfMonth()); // 월의 마지막 날
+        } else {
+            throw new IllegalArgumentException("Invalid dateType: " + dateType);
+        }
+
+        return settlementResultRepository.findByDateTypeAndStartDateBetween(dateType, start, end);
+    }
+}
+

--- a/src/main/java/com/sparta/settlementservice/settlement/service/Top5StatisticsService.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/service/Top5StatisticsService.java
@@ -1,0 +1,40 @@
+package com.sparta.settlementservice.settlement.service;
+
+
+import com.sparta.settlementservice.batch.entity.Top5Statistics;
+import com.sparta.settlementservice.batch.repo.Top5StatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class Top5StatisticsService {
+
+    private final Top5StatisticsRepository top5StatisticsRepository;
+
+    public List<Top5Statistics> getTop5Statistics(String dateType, LocalDate startDate, String staticType) {
+        LocalDate start, end;
+
+        if ("DAILY".equalsIgnoreCase(dateType)) {
+            start = startDate;
+            end = startDate;
+        } else if ("WEEKLY".equalsIgnoreCase(dateType)) {
+            start = startDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)); // 주의 월요일
+            end = startDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)); // 주의 일요일
+        } else if ("MONTHLY".equalsIgnoreCase(dateType)) {
+            start = startDate.withDayOfMonth(1); // 월의 첫째 날
+            end = startDate.with(TemporalAdjusters.lastDayOfMonth()); // 월의 마지막 날
+        } else {
+            throw new IllegalArgumentException("Invalid dateType: " + dateType);
+        }
+
+        // DB 조회
+        return top5StatisticsRepository.findTop5ByDateTypeAndStartDateBetweenAndStaticTypeOrderByValueDesc(
+                dateType, start, end, staticType);
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/user/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/sparta/settlementservice/user/oauth2/CustomSuccessHandler.java
@@ -39,7 +39,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60 * 60 * 60L);
+        String token = jwtUtil.createJwt(username, role, 100 * 100 * 100L);
 
         response.addCookie(createCookie("Authorization", token));
         response.sendRedirect("http://localhost:3000/");


### PR DESCRIPTION
- Top5 조회 API (`/top5/{dateType}/{date}/{staticType}`) 추가
  - 특정 기간(일/주/월) 동안 조회수 또는 재생시간 기준 TOP5 조회

- SettlementResult 조회 API (`/settlement/{dateType}/{date}`) 추가
  - 특정 기간(일/주/월) 동안의 정산 결과 조회

- 받은 날짜를 기준으로 주/월 `startDate`, `endDate` 자동 계산 후 SQL 쿼리 실행
  - `WEEKLY`: 해당 날짜가 포함된 주의 월요일~일요일 조회
  - `MONTHLY`: 해당 날짜가 포함된 월의 1일~말일 조회

관련된 로직 최적화 및 API 호출 테스트 완료.