### PR TITLE
HikariCP 설정 개선 및 DB 커넥션 최적화

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/config/BatchConfig.java
+++ b/src/main/java/com/sparta/settlementservice/batch/config/BatchConfig.java
@@ -1,9 +1,6 @@
 package com.sparta.settlementservice.batch.config;
 
 
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.partition.PartitionHandler;
-import org.springframework.batch.core.partition.support.TaskExecutorPartitionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;

--- a/src/main/java/com/sparta/settlementservice/common/config/MasterDBConfig.java
+++ b/src/main/java/com/sparta/settlementservice/common/config/MasterDBConfig.java
@@ -1,5 +1,7 @@
 package com.sparta.settlementservice.common.config;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +29,17 @@ public class MasterDBConfig {
 
     @Primary
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource.master") //  Master DB 설정
-    public DataSource masterDBSource() {
-        return DataSourceBuilder.create().build();
+    @ConfigurationProperties(prefix = "spring.datasource.master")
+    public HikariDataSource masterDBSource() {
+        HikariDataSource dataSource = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+
+        // 커넥션 풀 크기 30으로 설정
+        dataSource.setMaximumPoolSize(100);
+        // 30초 동안 사용되지 않은 커넥션 자동 종료
+        dataSource.setIdleTimeout(30000);
+        return dataSource;
     }
 
 

--- a/src/main/java/com/sparta/settlementservice/common/config/SlaveDBConfig.java
+++ b/src/main/java/com/sparta/settlementservice/common/config/SlaveDBConfig.java
@@ -1,5 +1,6 @@
 package com.sparta.settlementservice.common.config;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -22,9 +23,18 @@ import java.util.Properties;
 public class SlaveDBConfig {
 
     @Bean
-    @ConfigurationProperties(prefix = "spring.datasource.slave") //  Slave DB 설정
-    public DataSource slaveDBSource() {
-        return DataSourceBuilder.create().build();
+    @ConfigurationProperties(prefix = "spring.datasource.slave")
+    public HikariDataSource slaveDBSource() {
+        HikariDataSource dataSource = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+
+        // 커넥션 풀 크기 30으로 설정
+        dataSource.setMaximumPoolSize(100);
+        // 30초 동안 사용되지 않은 커넥션 자동 종료
+        dataSource.setIdleTimeout(30000);
+
+        return dataSource;
     }
 
     @Bean

--- a/src/main/java/com/sparta/settlementservice/streaming/service/StreamingService.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/service/StreamingService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class StreamingService {
 

--- a/src/main/java/com/sparta/settlementservice/streaming/service/VideoViewHelper.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/service/VideoViewHelper.java
@@ -6,13 +6,9 @@ import com.sparta.settlementservice.streaming.entity.VideoViewHistory;
 import com.sparta.settlementservice.streaming.repository.DailyVideoViewRepository;
 import com.sparta.settlementservice.streaming.repository.VideoRepository;
 import com.sparta.settlementservice.streaming.repository.VideoViewHistoryRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -35,21 +31,13 @@ public class VideoViewHelper {
         return 0; // 시청 기록이 생성되었거나 업데이트되었음을 반환
     }
 
-    // 재생 시간 업데이트
+    @Transactional
     public void createVideoViewHistory(Long userId, Long videoId, Long currentPosition) {
-        // 기존 시청 기록 조회
-        Optional<VideoViewHistory> optionalHistory = videoViewHistoryRepository.findByUserIdAndVideoId(userId, videoId);
+        VideoViewHistory history = videoViewHistoryRepository
+                .findByUserIdAndVideoId(userId, videoId)
+                .orElse(new VideoViewHistory(userId, videoId, currentPosition));
 
-        if (optionalHistory.isPresent()) {
-            // 기존 데이터가 존재하면 currentPosition만 업데이트
-            VideoViewHistory history = optionalHistory.get();
-            history.setCurrentPosition(currentPosition);
-            videoViewHistoryRepository.save(history);
-        } else {
-            // 데이터가 없으면 새로 저장 (userId, videoId, currentPosition 포함)
-            VideoViewHistory history = new VideoViewHistory(userId, videoId, currentPosition);
-            videoViewHistoryRepository.save(history);
-        }
-
+        history.setCurrentPosition(currentPosition);
+        videoViewHistoryRepository.save(history);
     }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -8,13 +8,21 @@ spring:
       username: root
       password: manager
       driver-class-name: com.mysql.cj.jdbc.Driver
+#      hikari:
+#        maximum-pool-size: 30  # 마스터 커넥션 풀 30개  , 설정이 안먹히는 관계로 db config에 pool사이즈 작성
 
     slave:
       jdbc-url: jdbc:mysql://mysql-slave:3306/settlementdb?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
       username: root
       password: manager
       driver-class-name: com.mysql.cj.jdbc.Driver
+#      hikari:
+#        maximum-pool-size: 30  # 슬레이브 커넥션 풀 30개
 
+logging:
+  level:
+    com.zaxxer.hikari: DEBUG
+    org.springframework.cache: trace  #  HikariCP 디버그 로그 활성화 추가
 
   data:
     redis:
@@ -22,6 +30,7 @@ spring:
       port: 6379
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
       naming:
@@ -69,6 +78,3 @@ spring:
 jwt:
   secret: ${JWT_SECRET:default_secret}
 
-logging:
-  level:
-    org.springframework.cache: trace # Redis 관련 로깅 레벨 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
+
 spring:
+  profiles:
+    active: default
+
   application:
     name: settlement-service
 


### PR DESCRIPTION
- `open-in-view: false` 설정 추가하여 OSIV 비활성화
- HikariCP 로깅 활성화 및 각 DB 설정에 커넥션 풀 최적화 적용
  - `maximumPoolSize=100` 설정
  - `idleTimeout=30000`(30초 후 미사용 커넥션 자동 종료) 추가
- `createVideoViewHistory` 메서드 리팩토링
  - `save` 메서드로 Insert/Update 로직 통합하여 코드 간소화