### PR TITLE
play, pause API 반환 타입을 ResponseEntity + DTO 구조로 개선

### DIFF
--- a/src/main/java/com/sparta/settlementservice/batch/repo/slave/SettlementResultRepository.java
+++ b/src/main/java/com/sparta/settlementservice/batch/repo/slave/SettlementResultRepository.java
@@ -7,5 +7,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface SettlementResultRepository extends JpaRepository<SettlementResult, Long> {
-    List<SettlementResult> findByDateTypeAndStartDateBetween(String dateType, LocalDate start, LocalDate end);
+    List<SettlementResult> findByVideoIdAndDateTypeAndStartDateBetween(
+            Long videoId, String dateType, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/sparta/settlementservice/settlement/controller/SettlementController.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/controller/SettlementController.java
@@ -19,14 +19,15 @@ public class SettlementController {
 
     private final SettlementService settlementService;
 
-    @GetMapping("/{dateType}/{date}")
+    @GetMapping("/{videoId}/{dateType}/{date}")
     public ResponseEntity<List<SettlementResult>> getSettlement(
+            @PathVariable Long videoId,
             @PathVariable String dateType,
             @PathVariable String date) {
         System.out.println("Received dateType: " + dateType);  // 로그 추가
         System.out.println("Received date: " + date);  // 로그 추가
         LocalDate startDate = LocalDate.parse(date);
-        List<SettlementResult> settlementList = settlementService.getSettlement(dateType, startDate);
+        List<SettlementResult> settlementList = settlementService.getSettlement(videoId, dateType, startDate);
 
         return ResponseEntity.ok(settlementList);
     }

--- a/src/main/java/com/sparta/settlementservice/settlement/service/SettlementService.java
+++ b/src/main/java/com/sparta/settlementservice/settlement/service/SettlementService.java
@@ -16,7 +16,7 @@ public class SettlementService {
 
     private final SettlementResultRepository settlementResultRepository; //  변경됨
 
-    public List<SettlementResult> getSettlement(String dateType, LocalDate startDate) { // Settlement → SettlementResult
+    public List<SettlementResult> getSettlement(Long videoId, String dateType, LocalDate startDate) { // Settlement → SettlementResult
         LocalDate start, end;
         System.out.println(dateType);
         System.out.println(startDate);
@@ -33,7 +33,9 @@ public class SettlementService {
             throw new IllegalArgumentException("Invalid dateType: " + dateType);
         }
 
-        return settlementResultRepository.findByDateTypeAndStartDateBetween(dateType, start, end);
+        return settlementResultRepository.findByVideoIdAndDateTypeAndStartDateBetween(
+                videoId, dateType, start, end
+        );
     }
 }
 

--- a/src/main/java/com/sparta/settlementservice/streaming/controller/StreamingController.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/controller/StreamingController.java
@@ -1,10 +1,13 @@
 package com.sparta.settlementservice.streaming.controller;
 
 
+import com.sparta.settlementservice.streaming.dto.PauseResponse;
 import com.sparta.settlementservice.streaming.dto.PlayRequest;
+import com.sparta.settlementservice.streaming.dto.PlayResponse;
 import com.sparta.settlementservice.streaming.service.StreamingService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -16,21 +19,32 @@ public class StreamingController {
 
     //조회 수 증가 후 현재 재생시점 반환
     @PostMapping("/videos/{videoId}/play")
-    public int play(@PathVariable Long videoId
+    public ResponseEntity<PlayResponse> play(@PathVariable Long videoId
             , HttpServletRequest httpServletRequest
             , @RequestBody PlayRequest playRequest) {
-        return streamingService.play(videoId, httpServletRequest, playRequest);
+        PlayResponse result =  streamingService.play(videoId, httpServletRequest, playRequest);
+
+        if (!result.isSuccess()) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(result);
+        }
+
+        return ResponseEntity.ok(result);
     }
 
     // 현재 재생 시점 db에 저장
     @PostMapping("/users/{userId}/videos/{videoId}/pause")
-    public int pause(@PathVariable Long userId,
+    public ResponseEntity pause(@PathVariable Long userId,
                       @PathVariable Long videoId,
                       @RequestParam Long currentPosition) {
 
-        return streamingService.pause(userId, videoId, currentPosition);
+        PauseResponse result = streamingService.pause(userId, videoId, currentPosition);
+        if (!result.isSuccess()) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(result);
+        }
+        return ResponseEntity.ok(result);
     }
-
-
-
 }

--- a/src/main/java/com/sparta/settlementservice/streaming/dto/PauseResponse.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/dto/PauseResponse.java
@@ -1,0 +1,19 @@
+package com.sparta.settlementservice.streaming.dto;
+
+public class PauseResponse {
+    private boolean success;
+    private String message;
+
+    public PauseResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/streaming/dto/PlayResponse.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/dto/PlayResponse.java
@@ -1,0 +1,19 @@
+package com.sparta.settlementservice.streaming.dto;
+
+public class PlayResponse {
+    private boolean success;
+    private String message;
+
+    public PlayResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/sparta/settlementservice/streaming/service/StreamingService.java
+++ b/src/main/java/com/sparta/settlementservice/streaming/service/StreamingService.java
@@ -1,12 +1,14 @@
 package com.sparta.settlementservice.streaming.service;
 
 
+import com.sparta.settlementservice.streaming.dto.PauseResponse;
 import com.sparta.settlementservice.streaming.dto.PlayRequest;
+import com.sparta.settlementservice.streaming.dto.PlayResponse;
 import com.sparta.settlementservice.user.jwt.JWTUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +21,7 @@ public class StreamingService {
 
 
     // 동영상 재생 서비스
-    public int play(Long videoId, HttpServletRequest httpServletRequest, PlayRequest playRequest) {
+    public PlayResponse play(Long videoId, HttpServletRequest httpServletRequest, PlayRequest playRequest) {
         String jwtToken = jwtUtil.getTokenFromCookies(httpServletRequest);
         String ipAddress = ipHelper.getClientIp(httpServletRequest); // 헬퍼 사용
 
@@ -29,17 +31,18 @@ public class StreamingService {
 
 
         if (abusePreventionHelper.isAbusiveRequest(jwtToken, ipAddress)) { // 어뷰징 체크
-            System.out.println("어뷰징입니다.");
-            return 0;
+            return new PlayResponse(false, "어뷰징 요청입니다.");
         } else {
-            return videoViewHelper.createDailyVideoView(videoId,playRequest); // 헬퍼로 시청 기록 생성
+            videoViewHelper.createDailyVideoView(videoId, playRequest); // 헬퍼로 시청 기록 생성
+            return new PlayResponse(true, "시청 기록 저장 완료");
         }
 
     }
 
     // 정지(Pause) 메서드
-    public int pause(Long userId, Long videoId, Long currentPosition) {
-        return videoViewHelper.createVideoViewHistory(userId, videoId, currentPosition);
+    public PauseResponse pause(Long userId, Long videoId, Long currentPosition) {
+
+         return videoViewHelper.createVideoViewHistory(userId, videoId, currentPosition);
     }
 
 }

--- a/src/test/java/com/sparta/settlementservice/streaming/service/VideoViewHelperTest.java
+++ b/src/test/java/com/sparta/settlementservice/streaming/service/VideoViewHelperTest.java
@@ -1,5 +1,6 @@
 package com.sparta.settlementservice.streaming.service;
 
+import com.sparta.settlementservice.streaming.dto.PauseResponse;
 import com.sparta.settlementservice.streaming.repository.VideoRepository;
 import com.sparta.settlementservice.streaming.repository.VideoViewHistoryRepository;
 import org.junit.jupiter.api.Test;
@@ -8,8 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,15 +35,15 @@ class VideoViewHelperTest {
         Long userId = 1L;
         Long videoId = 100L;
         Long currentPosition = 600L; // 600초 재생
-        Long videoLength = 500L; // 영상 길이 500초
+        Long videoLength = 500L;
 
         when(videoRepository.findVideoLengthById(videoId)).thenReturn(videoLength);
 
-        // when & then
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            videoViewHelper.createVideoViewHistory(userId, videoId, currentPosition);
-        });
+        // when
+        PauseResponse response = videoViewHelper.createVideoViewHistory(userId, videoId, currentPosition);
 
-        assertEquals("현재 재생 위치가 영상 길이를 초과합니다.", exception.getMessage());
+        // then
+        assertFalse(response.isSuccess());
+        assertEquals("재생 위치가 영상 길이를 초과했습니다.", response.getMessage());
     }
 }


### PR DESCRIPTION
- 기존 int 응답에서 ResponseEntity<ResponseDto> 구조로 변경
- 응답 메시지 및 상태 코드 명확화
- 클라이언트 응답 처리 일관성 향상
- 비디오 영상 길이 테스트를 예외 처리 방식에서 ResponseEntity 반환 방식으로 변경